### PR TITLE
Narrow type for logos array using `as const`

### DIFF
--- a/exercises/01.preparing-for-the-build/01.problem.unstyled-markup/src/logos/logos.ts
+++ b/exercises/01.preparing-for-the-build/01.problem.unstyled-markup/src/logos/logos.ts
@@ -132,4 +132,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/01.preparing-for-the-build/01.solution.unstyled-markup/src/logos/logos.ts
+++ b/exercises/01.preparing-for-the-build/01.solution.unstyled-markup/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/01.preparing-for-the-build/02.problem.tailwind-config/src/logos/logos.ts
+++ b/exercises/01.preparing-for-the-build/02.problem.tailwind-config/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/01.preparing-for-the-build/02.solution.tailwind-config/src/logos/logos.ts
+++ b/exercises/01.preparing-for-the-build/02.solution.tailwind-config/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/01.problem.structural-layout/src/logos/logos.ts
+++ b/exercises/02.mobile-first/01.problem.structural-layout/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/01.solution.structural-layout/src/logos/logos.ts
+++ b/exercises/02.mobile-first/01.solution.structural-layout/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/02.problem.text-styles/src/logos/logos.ts
+++ b/exercises/02.mobile-first/02.problem.text-styles/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/02.solution.text-styles/src/logos/logos.ts
+++ b/exercises/02.mobile-first/02.solution.text-styles/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/03.problem.logo-list/src/logos/logos.ts
+++ b/exercises/02.mobile-first/03.problem.logo-list/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/02.mobile-first/03.solution.logo-list/src/logos/logos.ts
+++ b/exercises/02.mobile-first/03.solution.logo-list/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/01.problem.responsive-typography/src/logos/logos.ts
+++ b/exercises/03.responsive-design/01.problem.responsive-typography/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/01.solution.responsive-typography/src/logos/logos.ts
+++ b/exercises/03.responsive-design/01.solution.responsive-typography/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/02.problem.responsive-spacing/src/logos/logos.ts
+++ b/exercises/03.responsive-design/02.problem.responsive-spacing/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/02.solution.responsive-spacing/src/logos/logos.ts
+++ b/exercises/03.responsive-design/02.solution.responsive-spacing/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/03.problem.side-by-side-layout/src/logos/logos.ts
+++ b/exercises/03.responsive-design/03.problem.side-by-side-layout/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/03.solution.side-by-side-layout/src/logos/logos.ts
+++ b/exercises/03.responsive-design/03.solution.side-by-side-layout/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/04.problem.logo-grid/src/logos/logos.ts
+++ b/exercises/03.responsive-design/04.problem.logo-grid/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/03.responsive-design/04.solution.logo-grid/src/logos/logos.ts
+++ b/exercises/03.responsive-design/04.solution.logo-grid/src/logos/logos.ts
@@ -128,4 +128,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/04.art-directed-grid/01.problem.logo-coordinates/src/logos/logos.ts
+++ b/exercises/04.art-directed-grid/01.problem.logo-coordinates/src/logos/logos.ts
@@ -132,4 +132,4 @@ export const logos = [
 		alt: 'Sentry',
 		href: 'https://sentry.io',
 	},
-]
+] as const

--- a/exercises/04.art-directed-grid/01.solution.logo-coordinates/src/logos/logos.ts
+++ b/exercises/04.art-directed-grid/01.solution.logo-coordinates/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/04.art-directed-grid/02.problem.grid-class-composition/src/logos/logos.ts
+++ b/exercises/04.art-directed-grid/02.problem.grid-class-composition/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/04.art-directed-grid/02.solution.grid-class-composition/src/logos/logos.ts
+++ b/exercises/04.art-directed-grid/02.solution.grid-class-composition/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/05.interaction/01.problem.text-interactions/src/logos/logos.ts
+++ b/exercises/05.interaction/01.problem.text-interactions/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/05.interaction/01.solution.text-interactions/src/logos/logos.ts
+++ b/exercises/05.interaction/01.solution.text-interactions/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/05.interaction/02.problem.logo-grid-interactions/src/logos/logos.ts
+++ b/exercises/05.interaction/02.problem.logo-grid-interactions/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/05.interaction/02.solution.logo-grid-interactions/src/logos/logos.ts
+++ b/exercises/05.interaction/02.solution.logo-grid-interactions/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/01.problem.enter-animations/src/logos/logos.ts
+++ b/exercises/06.animation/01.problem.enter-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/01.solution.enter-animations/src/logos/logos.ts
+++ b/exercises/06.animation/01.solution.enter-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/02.problem.responsive-animations/src/logos/logos.ts
+++ b/exercises/06.animation/02.problem.responsive-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/02.solution.responsive-animations/src/logos/logos.ts
+++ b/exercises/06.animation/02.solution.responsive-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/03.problem.roll-reveal/src/logos/logos.ts
+++ b/exercises/06.animation/03.problem.roll-reveal/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/03.solution.roll-reveal/src/logos/logos.ts
+++ b/exercises/06.animation/03.solution.roll-reveal/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/04.problem.logo-stagger-reveal/src/logos/logos.ts
+++ b/exercises/06.animation/04.problem.logo-stagger-reveal/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/04.solution.logo-stagger-reveal/src/logos/logos.ts
+++ b/exercises/06.animation/04.solution.logo-stagger-reveal/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/05.problem.text-delay-adjustment/src/logos/logos.ts
+++ b/exercises/06.animation/05.problem.text-delay-adjustment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/06.animation/05.solution.text-delay-adjustment/src/logos/logos.ts
+++ b/exercises/06.animation/05.solution.text-delay-adjustment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/01.problem.vite-plugin/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/01.problem.vite-plugin/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/01.solution.vite-plugin/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/01.solution.vite-plugin/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/02.problem.css-theme-config/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/02.problem.css-theme-config/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/02.solution.css-theme-config/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/02.solution.css-theme-config/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/03.problem.font-sizes/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/03.problem.font-sizes/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/03.solution.font-sizes/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/03.solution.font-sizes/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/04.problem.keyframe-animations/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/04.problem.keyframe-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/07.upgrade-to-tailwind-v4/04.solution.keyframe-animations/src/logos/logos.ts
+++ b/exercises/07.upgrade-to-tailwind-v4/04.solution.keyframe-animations/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/01.problem.sub-grid/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/01.problem.sub-grid/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/01.solution.sub-grid/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/01.solution.sub-grid/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/02.problem.vertical-gap/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/02.problem.vertical-gap/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/02.solution.vertical-gap/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/02.solution.vertical-gap/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/03.problem.children-grid-alignment/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/03.problem.children-grid-alignment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/03.solution.children-grid-alignment/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/03.solution.children-grid-alignment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/04.problem.content-placement/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/04.problem.content-placement/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/04.solution.content-placement/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/04.solution.content-placement/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/05.problem.content-alignment/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/05.problem.content-alignment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const

--- a/exercises/08.subgrid-alignment/05.solution.content-alignment/src/logos/logos.ts
+++ b/exercises/08.subgrid-alignment/05.solution.content-alignment/src/logos/logos.ts
@@ -170,4 +170,4 @@ export const logos = [
 		column: 5,
 		row: 5,
 	},
-]
+] as const


### PR DESCRIPTION
## Obstacle encountered
The `logos` type is wide. There's no autocomplete in exercise **"Art directed Grid - 02 Grid Class Composition"**

![ภาพ](https://github.com/epicweb-dev/pixel-perfect-tailwind/assets/85487998/bdf53a82-4b17-4a94-ac2a-55786af66d9a)

The exercise comment suggests that the record type will perform type checking to catch incorrect row / column entries
```
/*
  🦺 The two TypeScript 'Records' below ensure that the lookup objects 
  have keys that match the possible values of the 'column' and 'row'
  properties on the 'logos' array.
*/
```

## Solution

This PR appends `as const` to the logos array in all exercises to narrow the `logos` type, providing object fields auto complete and warn users if they provided an incorrect row / column number
![ภาพ](https://github.com/epicweb-dev/pixel-perfect-tailwind/assets/85487998/32991050-e9a3-4a43-923a-25ac1c85f052)
